### PR TITLE
Add emoji selector to chat input

### DIFF
--- a/src/app/components/room/room.module.ts
+++ b/src/app/components/room/room.module.ts
@@ -12,6 +12,7 @@ import { RoomAvatarInfoRentableBotComponent } from './widgets/avatarinfo/compone
 import { RoomChatInputComponent } from './widgets/chatinput/component';
 import { RoomChatInputStyleSelectorComponent } from './widgets/chatinput/styleselector/component';
 import { ChooserWidgetBaseComponent } from './widgets/choosers/base/base.component';
+import { RoomChatInputEmojiSelectorComponent } from './widgets/chatinput/emojiselector/component';
 import { ChooserWidgetFurniComponent } from './widgets/choosers/furni/furni.component';
 import { ChooserWidgetUserComponent } from './widgets/choosers/user/user.component';
 import { FriendRequestDialogComponent } from './widgets/friendrequest/components/dialog/dialog.component';
@@ -52,6 +53,7 @@ import { FloorplanModule } from './floorplan/floorplan.module';
         RoomChatComponent,
         RoomChatItemComponent,
         RoomChatInputStyleSelectorComponent,
+        RoomChatInputEmojiSelectorComponent,
         RoomInfoStandMainComponent,
         RoomInfoStandBotComponent,
         RoomInfoStandFurniComponent,
@@ -96,6 +98,7 @@ import { FloorplanModule } from './floorplan/floorplan.module';
         RoomChatComponent,
         RoomChatItemComponent,
         RoomChatInputStyleSelectorComponent,
+        RoomChatInputEmojiSelectorComponent,
         RoomInfoStandMainComponent,
         RoomInfoStandBotComponent,
         RoomInfoStandFurniComponent,

--- a/src/app/components/room/widgets/chatinput/component.ts
+++ b/src/app/components/room/widgets/chatinput/component.ts
@@ -19,6 +19,7 @@ import { RoomWidgetChatTypingMessage } from '../messages/RoomWidgetChatTypingMes
             </div>
         </div>
         <nitro-room-chatinput-styleselector-component (styleSelected)="onStyleSelected($event)"></nitro-room-chatinput-styleselector-component>
+        <nitro-room-chatinput-emojiselector-component (emojiSelected)="onEmojiSelected($event)"></nitro-room-chatinput-emojiselector-component>
     </div>`
 })
 export class RoomChatInputComponent extends ConversionTrackingWidget implements OnInit, OnDestroy, AfterViewInit
@@ -283,6 +284,22 @@ export class RoomChatInputComponent extends ConversionTrackingWidget implements 
         this.currentStyle       = styleId;
         this.needsStyleUpdate   = true;
     }
+    public onEmojiSelected(emoji: string): void
+    {
+        const input = (this.chatInputView && this.chatInputView.nativeElement);
+
+        if(!input) return;
+
+        input.value = (input.value + emoji);
+        input.parentElement.dataset.value = input.value;
+
+        this.lastContent = input.value;
+        this.isTyping = true;
+        this.startTypingTimer();
+        this.startIdleTimer();
+        this.setInputFocus();
+    }
+
 
     private sendChatFromInputField(shiftKey: boolean = false): void
     {

--- a/src/app/components/room/widgets/chatinput/emojiselector/component.ts
+++ b/src/app/components/room/widgets/chatinput/emojiselector/component.ts
@@ -1,0 +1,60 @@
+import { Component, EventEmitter, OnDestroy, OnInit, Output } from '@angular/core';
+
+@Component({
+    selector: 'nitro-room-chatinput-emojiselector-component',
+    template: `
+    <div class="nitro-room-chatinput-emojiselector-component">
+        <i class="icon icon-sign-smile" (click)="toggleSelector()"></i>
+        <div [bringToTop] class="nitro-emojiselector card p-3" [ngClass]="{ 'active': showEmojis }">
+            <div class="grid-container w-100">
+                <div class="grid-items grid-5">
+                    <div class="d-flex flex-column item-detail justify-content-center align-items-center" *ngFor="let emoji of emojis" (click)="selectEmoji(emoji)">
+                        <span class="emoji">{{ emoji }}</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>`
+})
+export class RoomChatInputEmojiSelectorComponent implements OnInit, OnDestroy
+{
+    @Output()
+    public emojiSelected = new EventEmitter<string>();
+
+    public showEmojis = false;
+    public emojis: string[] = ['😀','😁','😂','😅','😍','😎','😭','😡','👍','👎','❤️','🎉','😜','🤔','😢','🤯','😇','😱','🙌','💯'];
+
+    public ngOnInit(): void
+    {}
+
+    public ngOnDestroy(): void
+    {
+        this.hideSelector();
+    }
+
+    private showSelector(): void
+    {
+        this.showEmojis = true;
+    }
+
+    private hideSelector(): void
+    {
+        this.showEmojis = false;
+    }
+
+    public toggleSelector(): void
+    {
+        if(this.showEmojis)
+        {
+            this.hideSelector();
+            return;
+        }
+        this.showSelector();
+    }
+
+    public selectEmoji(emoji: string): void
+    {
+        this.emojiSelected.emit(emoji);
+        this.hideSelector();
+    }
+}

--- a/src/app/components/room/widgets/chatinput/emojiselector/index.scss
+++ b/src/app/components/room/widgets/chatinput/emojiselector/index.scss
@@ -1,0 +1,48 @@
+.nitro-room-chatinput-emojiselector-component {
+    display: flex;
+    position: relative;
+    right: 55px;
+    pointer-events: all;
+    height: 100%;
+
+    i.icon {
+        cursor: pointer;
+        align-self: center;
+    }
+
+    .nitro-emojiselector {
+        position: absolute;
+        width: 200px;
+        top: -4px;
+        transition: transform 0.22s ease-in-out;
+        transform: translate(-50%, -50%) scale(0);
+
+        &.active {
+            visibility: visible;
+            transform: translate(-50%, -100%) scale(1);
+        }
+
+        .grid-container {
+
+            .grid-items {
+                margin-top: -7px;
+
+                .item-detail {
+                    height: 30px;
+                    max-height: 30px;
+                    width: calc(1 / 5 * 100% - (1 - 1 / 5) * 7px);
+                    margin: 7px 7px 0 0;
+                    overflow: visible;
+
+                    &:hover {
+                        cursor: pointer;
+                    }
+
+                    .emoji {
+                        font-size: 18px;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/app/components/room/widgets/chatinput/index.scss
+++ b/src/app/components/room/widgets/chatinput/index.scss
@@ -87,3 +87,4 @@
 }
 
 @import './styleselector';
+@import './emojiselector';


### PR DESCRIPTION
## Summary
- add a simple emoji selector component
- wire emoji selector into the chat input component
- export the component from the room module
- include styles for emoji selector

## Testing
- `yarn build` *(fails: @ngx-env/builder missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_687b1434abd88324a704f80db0d3dcab