### PR TITLE
Fix sample unload cleanup

### DIFF
--- a/libs/nitro-renderer/src/nitro/sound/music/MusicController.ts
+++ b/libs/nitro-renderer/src/nitro/sound/music/MusicController.ts
@@ -223,7 +223,30 @@ export class MusicController implements IMusicController
 
     public samplesUnloaded(_arg_1: number[]): void
     {
-        throw new Error('Method not implemented.');
+        if(!_arg_1 || !_arg_1.length) return;
+
+        for(const songId of _arg_1)
+        {
+            if(this._requestedSongs.has(songId))
+            {
+                this._requestedSongs.delete(songId);
+            }
+
+            if(this._availableSongs.has(songId))
+            {
+                this._availableSongs.delete(songId);
+            }
+
+            for(let i = 0; i < this._songRequestsPerPriority.length; i++)
+            {
+                const request = this._songRequestsPerPriority[i];
+
+                if(request && request.songId === songId)
+                {
+                    this._songRequestsPerPriority[i] = undefined;
+                }
+            }
+        }
     }
 
     protected onTraxSongComplete(k: SoundManagerEvent): void


### PR DESCRIPTION
## Summary
- ensure unloaded samples remove their songs from caches

## Testing
- `yarn build` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_687c57a61d5c8324b0e477d11d99a4be